### PR TITLE
fixed num_nodes is empty issue for 1.4+ pytorch geometric package with param inspection

### DIFF
--- a/conv.py
+++ b/conv.py
@@ -50,7 +50,7 @@ class HGTConv(MessagePassing):
         return self.propagate(edge_index, node_inp=node_inp, node_type=node_type, \
                               edge_type=edge_type, edge_time = edge_time)
 
-    def message(self, edge_index_i, node_inp_i, node_inp_j, node_type_i, node_type_j, edge_type, edge_time, num_nodes):
+    def message(self, edge_index_i, node_inp_i, node_inp_j, node_type_i, node_type_j, edge_type, edge_time):
         '''
             j: source, i: target; <j, i>
         '''


### PR DESCRIPTION
Removed unused param. Otherwise the error below will be raised.

```bash
Traceback (most recent call last):
  File "/home/zhihan/.conda/envs/eth/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/zhihan/.conda/envs/eth/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/zhihan/.conda/envs/eth/lib/python3.7/cProfile.py", line 185, in <module>
    main()
  File "/home/zhihan/.conda/envs/eth/lib/python3.7/cProfile.py", line 178, in main
    runctx(code, globs, None, options.outfile, options.sort)
  File "/home/zhihan/.conda/envs/eth/lib/python3.7/cProfile.py", line 20, in runctx
    filename, sort)
  File "/home/zhihan/.conda/envs/eth/lib/python3.7/profile.py", line 62, in runctx
    prof.runctx(statement, globals, locals)
  File "/home/zhihan/.conda/envs/eth/lib/python3.7/cProfile.py", line 100, in runctx
    exec(cmd, globals, locals)
  File "train_paper_field.py", line 241, in <module>
    edge_time.to(device), edge_index.to(device), edge_type.to(device))
  File "/home/zhihan/dev/eth/pyHGT/model.py", line 78, in forward
    meta_xs = gc(meta_xs, node_type, edge_index, edge_type, edge_time)
  File "/home/zhihan/.conda/envs/eth/lib/python3.7/site-packages/torch/nn/modules/module.py", line 550, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/zhihan/dev/eth/pyHGT/conv.py", line 162, in forward
    return self.base_conv(meta_xs, node_type, edge_index, edge_type, edge_time)
  File "/home/zhihan/.conda/envs/eth/lib/python3.7/site-packages/torch/nn/modules/module.py", line 550, in __call__
    result = self.forward(*input, **kwargs)
  File "/home/zhihan/dev/eth/pyHGT/conv.py", line 51, in forward
    edge_type=edge_type, edge_time = edge_time)
  File "/home/zhihan/.conda/envs/eth/lib/python3.7/site-packages/torch_geometric/nn/conv/message_passing.py", line 257, in propagate
    msg_kwargs = self.__distribute__(self.__msg_params__, kwargs)
  File "/home/zhihan/.conda/envs/eth/lib/python3.7/site-packages/torch_geometric/nn/conv/message_passing.py", line 180, in __distribute__
    raise TypeError(f'Required parameter {key} is empty.')
TypeError: Required parameter num_nodes is empty.

```